### PR TITLE
Add uppercase for proper compile

### DIFF
--- a/daedalus/DaedalusExcept.cpp
+++ b/daedalus/DaedalusExcept.cpp
@@ -1,4 +1,4 @@
-#include "daedalusexcept.h"
+#include "DaedalusExcept.h"
 
 using namespace Daedalus;
 


### PR DESCRIPTION
When trying to compile OpenGothic, after successful cmake, make shows the following error:
fatal error: daedalusexcept.h: No such file or directory
 #include "daedalusexcept.h"
                ^~~~~~~~~~~~~~
compilation terminated.
And the correct file is DaedalusExcept.h.