### PR TITLE
zCCSLib: fix improper reading of contents in binary archives

### DIFF
--- a/zenload/zCCSLib.cpp
+++ b/zenload/zCCSLib.cpp
@@ -77,10 +77,21 @@ void zCCSLib::readObjectData(ZenParser& parser)
         {
         ZenParser::ChunkHeader messageHeader;
         parser.readChunkStart(messageHeader);
-        ReadObjectProperties(parser,
-                             Prop("subType", blk.atomicBlockData.command.subType),
-                             Prop("text", blk.atomicBlockData.command.text),
-                             Prop("name", blk.atomicBlockData.command.name));
+
+        if (parser.getZenHeader().fileType == ZenParser::FT_BINARY) {
+            uint8_t subType;
+            ReadObjectProperties(parser,
+                                 Prop("subType", subType),
+                                 Prop("text", blk.atomicBlockData.command.text),
+                                 Prop("name", blk.atomicBlockData.command.name));
+            blk.atomicBlockData.command.subType = subType;
+        } else {
+            ReadObjectProperties(parser,
+                                 Prop("subType", blk.atomicBlockData.command.subType),
+                                 Prop("text", blk.atomicBlockData.command.text),
+                                 Prop("name", blk.atomicBlockData.command.name));
+        }
+
 
         //LogInfo() << "Read message: " << blk.atomicBlockData.command.name;
         if(!parser.readChunkEnd())


### PR DESCRIPTION
Hey there,
while browsing through the code and trying out reading from actual files I noticed this problem with Gothic 1.
The zCCSLib parser would fail at various stages and would omit the first three chars of all messages text as 
they were considered to be part of the `subType`. 

![image](https://user-images.githubusercontent.com/20187490/118857535-70cf1b80-b8d8-11eb-99c1-f740a80a468f.png)

As you can see my copy of Gothic 1.08k from GOG (as well as my patched retail version of Gothic) only uses 
one byte to represent the `subType`. This patch fixes that issue. It does not affect Gothic 2 since it uses BIN_SAFE
archives for storing the zCCSLib (and there an enum type is used).