### PR TITLE
Fix build error due to missing cstring include.

### DIFF
--- a/vdfs/fileIndex.cpp
+++ b/vdfs/fileIndex.cpp
@@ -1,5 +1,6 @@
 #include "fileIndex.h"
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <regex>


### PR DESCRIPTION
vdfs/fileIndex.cpp: In member function ‘bool VDFS::FileIndex::getFileData(const char*, std::vector<unsigned char>&) const’:
vdfs/fileIndex.cpp:115:13: error: ‘strlen’ is not a member of ‘std’; did you mean ‘mbrlen’?
  115 |     if(std::strlen(file)<64){
      |             ^~~~~~
      |             mbrlen
vdfs/fileIndex.cpp:116:12: error: ‘strcpy’ is not a member of ‘std’
  116 |       std::strcpy(upperedC,file); // cheap upper-case
      |            ^~~~~~
vdfs/fileIndex.cpp: In member function ‘bool VDFS::FileIndex::hasFile(const std::string&) const’:
vdfs/fileIndex.cpp:151:12: error: ‘strcpy’ is not a member of ‘std’
  151 |       std::strcpy(upperedC,file.c_str()); // cheap upper-case
      |            ^~~~~~

Signed-off-by: lns <matzeton@googlemail.com>