### PR TITLE
Fix few sizing issues for integer types

### DIFF
--- a/zenload/zTypes.h
+++ b/zenload/zTypes.h
@@ -330,7 +330,7 @@ namespace ZenLoad
 
         struct
         {
-            int         stateNum=0;
+            int32_t     stateNum = 0;
             std::string triggerTarget;
             std::string useWithItem;
             std::string conditionFunc;
@@ -520,9 +520,9 @@ namespace ZenLoad
             bool fall    = false;
             } touchDamage;
 
-          float damageRepeatDelaySec = 0;
-          float damageVolDownScale   = 0;
-          int   damageCollType       = 0;
+          float   damageRepeatDelaySec = 0;
+          float   damageVolDownScale   = 0;
+          int32_t damageCollType       = 0;
         } oCTouchDamage;
 
         std::vector<zCVobData> childVobs;

--- a/zenload/zenParser.cpp
+++ b/zenload/zenParser.cpp
@@ -449,7 +449,7 @@ void ZenParser::readWorld(oCWorldData& info, FileVersion version) {
 void ZenParser::readPresets(std::vector<zCVobData>& vobs, ZenParser::FileVersion version) {
   LogInfo() << "ZEN: Reading presets...";
 
-  int numVobLightPresets = 0;
+  int32_t numVobLightPresets = 0;
   getImpl()->readEntry("numVobLightPresets",numVobLightPresets);
   if(numVobLightPresets<0)
     return;

--- a/zenload/ztex2dds.cpp
+++ b/zenload/ztex2dds.cpp
@@ -324,7 +324,7 @@ namespace ZenLoad
             }
         }
         /* Mipmaps */
-        MipmapCount = std::max(1u, ZTexHeader.TexInfo.MipMaps);
+        MipmapCount = std::max(1, static_cast<int>(ZTexHeader.TexInfo.MipMaps));
         BufferSize = 0;
         for (MipmapLevel = 0; MipmapLevel < MipmapCount; MipmapLevel++)
             BufferSize += GetMipmapSize(ZTexHeader.TexInfo.Format,


### PR DESCRIPTION
There are environments where `int` != `int32_t`, (the most hilarious one being gcc for nintendo 3ds, where they are both 4 bytes) which causes compilation to fail in some areas. 

The code already uses sized ints for parsing binary data almost everywhere, this just covers the few missing cases; Also fixes one annoying `max` which compared sized uint with unsized. (and casted it to signed)