### PR TITLE
Remove libsquish from submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/libsquish"]
-	path = lib/libsquish
-	url = https://github.com/tito/libsquish.git
 [submodule "lib/physfs"]
 	path = lib/physfs
   url = https://github.com/physfs-mirror/PhysicsFS.git


### PR DESCRIPTION
This causes issues with cloning ZenLib recursively in some setups, and also was not intended to be left in I think.

Fixes 68807e6ca1376e7cd6cb0ec470e2bd8d12d6331d